### PR TITLE
Remove CMAKE_LD_FLAGS

### DIFF
--- a/principia_make.sh
+++ b/principia_make.sh
@@ -5,7 +5,6 @@ cmake \
     -DCMAKE_CXX_COMPILER:FILEPATH=`which clang++` \
     -DCMAKE_C_FLAGS="${C_FLAGS?}" \
     -DCMAKE_CXX_FLAGS="${CXX_FLAGS?}" \
-    -DCMAKE_LD_FLAGS="${LD_FLAGS?}" \
     -DBUILD_SHARED_LIBS=OFF \
     -DZFP_WITH_OPENMP=OFF \
     ..


### PR DESCRIPTION
`CMAKE_LD_FLAGS` isn't recognized by CMake:

    CMake Warning:
      Manually-specified variables were not used by the project:
    
        CMAKE_LD_FLAGS

The flags wouldn't have been used anyways, since a static library is
generated and `ar` doesn't recognize `ld` flags.